### PR TITLE
feat: dynamic content

### DIFF
--- a/Configuration/NodeTypes.Content.Hotspot.yaml
+++ b/Configuration/NodeTypes.Content.Hotspot.yaml
@@ -1,6 +1,7 @@
 'Gerdemann.ImageHotspots:Content.Hotspot':
   superTypes:
     'Neos.Neos:Content': true
+    'Gerdemann.ImageHotspots:Mixin.HotspotContent': true
   constraints:
     nodeTypes:
       '*': false
@@ -24,7 +25,7 @@
           label: i18n
           tab: 'general'
           icon: 'icon-camera'
-          position: 10
+          position: 20
   properties:
     top:
       type: string

--- a/Configuration/NodeTypes.Mixin.HotspotContent.yaml
+++ b/Configuration/NodeTypes.Mixin.HotspotContent.yaml
@@ -1,0 +1,30 @@
+'Gerdemann.ImageHotspots:Mixin.HotspotContent':
+  abstract: true
+  childNodes:
+    content:
+      type: 'Neos.Neos:ContentCollection'
+  ui:
+    inspector:
+      groups:
+        contentSettings:
+          label: i18n
+          tab: 'general'
+          icon: 'fas fa-chalkboard'
+          position: 30
+  properties:
+    contentBoxWidth:
+      type: integer
+      defaultValue: 300
+      ui:
+        label: i18n
+        reloadIfChanged: true
+        inspector:
+          group: 'contentSettings'
+    contentBoxPadding:
+      type: string
+      defaultValue: '15px'
+      ui:
+        label: i18n
+        reloadIfChanged: true
+        inspector:
+          group: 'contentSettings'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 **Attention!** This package is currently in development.
 
 **ToDos:**
-* Add support for editable PopUp Content 
 * Support for Neos 8
 
 ## Installation
@@ -34,6 +33,13 @@ prototype(Neos.Neos:Page).hotspotBackendJavaScript >
 ## Change icon fallback
 
 Just overwrite the `Gerdemann.ImageHotspots:Utility.IconFallback` fusion prototype.
+
+## Change the rendering of the content box
+
+Just overwrite the (renderer of the) `Gerdemann.ImageHotspots:Content.HotspotContent` fusion prototype.
+
+It is also possible to create own NodeTypes that inherit from `Gerdemann.ImageHotspots:Content.Hotspot`.
+To disable unnecessary properties just disable the supertype `Gerdemann.ImageHotspots:Mixin.HotspotContent` in the new NodeType.
 
 ## License
 

--- a/Resources/Private/Fusion/Component/Atom/Hotspot/Hotspot.fusion
+++ b/Resources/Private/Fusion/Component/Atom/Hotspot/Hotspot.fusion
@@ -1,4 +1,5 @@
 prototype(Gerdemann.ImageHotspots:Component.Atom.Hotspot) < prototype(Neos.Fusion:Component) {
+    // API
     top = 50
     left = 50
     iconUri = ''
@@ -8,9 +9,8 @@ prototype(Gerdemann.ImageHotspots:Component.Atom.Hotspot) < prototype(Neos.Fusio
             <div class="imagehotspot-hotspot__button">
                 <img src={props.iconUri} alt="Hotspot" />
             </div>
-            <div class="imagehotspot-hotspot__label">
-                <h4>This is the title</h4>
-                <p>This is some text that goes in the label. It describes the item.</p>
+            <div class="imagehotspot-hotspot__content-collapse">
+                {props.content}
             </div>
         </div>
     `

--- a/Resources/Private/Fusion/Component/Atom/HotspotContent/HotspotContent.fusion
+++ b/Resources/Private/Fusion/Component/Atom/HotspotContent/HotspotContent.fusion
@@ -1,0 +1,24 @@
+prototype(Gerdemann.ImageHotspots:Component.Atom.HotspotContent) < prototype(Neos.Fusion:Component) {
+    // API
+    contentBoxWidth = '500px'
+    contentBoxPadding = '15px'
+    content = ''
+
+    // Implementation
+    contentBoxStyles = ''
+    contentBoxStyles.@process.setWidth = ${value + ' width: ' + this.contentBoxWidth + 'px;'}
+    contentBoxStyles.@process.setWidth.@if.isSet = ${this.contentBoxWidth}
+
+    contentInnerBoxStyles = ''
+    contentInnerBoxStyles.@process.setPadding = ${value + ' padding: ' + this.contentBoxPadding + ';'}
+    contentInnerBoxStyles.@process.setPadding.@if.isSet = ${this.contentBoxPadding}
+
+    // Renderer
+    renderer = afx`
+        <div class="imagehotspot-hotspot__content" style={props.contentBoxStyles}>
+            <div class="imagehotspot-hotspot-content" style={props.contentInnerBoxStyles}>
+                {props.content}
+            </div>
+        </div>
+    `
+}

--- a/Resources/Private/Fusion/Content/Hotspot.fusion
+++ b/Resources/Private/Fusion/Content/Hotspot.fusion
@@ -1,4 +1,5 @@
 prototype(Gerdemann.ImageHotspots:Content.Hotspot) < prototype(Neos.Neos:ContentComponent) {
+    // Renderer
     renderer = Gerdemann.ImageHotspots:Component.Atom.Hotspot {
         top = ${q(node).property('top')}
         left = ${q(node).property('left')}
@@ -19,5 +20,7 @@ prototype(Gerdemann.ImageHotspots:Content.Hotspot) < prototype(Neos.Neos:Content
                 renderer = Gerdemann.ImageHotspots:Utility.IconFallback
             }
         }
+
+        content = Gerdemann.ImageHotspots:Content.HotspotContent
     }
 }

--- a/Resources/Private/Fusion/Content/HotspotContent.fusion
+++ b/Resources/Private/Fusion/Content/HotspotContent.fusion
@@ -1,0 +1,15 @@
+prototype(Gerdemann.ImageHotspots:Content.HotspotContent) < prototype(Neos.Neos:ContentComponent) {
+    // API
+    contentBoxWidth = ${q(node).property('contentBoxWidth')}
+    contentBoxPadding = ${q(node).property('contentBoxPadding')}
+
+    // Renderer
+    renderer = Gerdemann.ImageHotspots:Component.Atom.HotspotContent {
+        contentBoxWidth = ${props.contentBoxWidth}
+        contentBoxPadding = ${props.contentBoxPadding}
+
+        content = Neos.Neos:ContentCollection {
+            nodePath = 'content'
+        }
+    }
+}

--- a/Resources/Private/Translations/de/NodeTypes/Content/Hotspot.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Content/Hotspot.xlf
@@ -6,10 +6,14 @@
                 <source>Hotspot</source>
                 <target xml:lang="de">Hotspot</target>
             </trans-unit>
+
+            <!-- tabs -->
             <trans-unit id="tabs.general" xml:space="preserve" approved="yes">
                 <source>General</source>
                 <target xml:lang="de">Allgemein</target>
             </trans-unit>
+
+            <!-- groups -->
             <trans-unit id="groups.position" xml:space="preserve" approved="yes">
                 <source>Position</source>
                 <target xml:lang="de">Position</target>
@@ -18,6 +22,8 @@
                 <source>Icon</source>
                 <target xml:lang="de">Icon</target>
             </trans-unit>
+
+            <!-- properties -->
             <trans-unit id="properties.top" xml:space="preserve" approved="yes">
                 <source>From top</source>
                 <target xml:lang="de">Von oben</target>

--- a/Resources/Private/Translations/de/NodeTypes/Mixin/HotspotContent.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Mixin/HotspotContent.xlf
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file original="" product-name="Gerdemann.ImageHotspots" source-language="en" datatype="plaintext" target-language="de">
+        <body>
+            <trans-unit id="groups.contentSettings" xml:space="preserve" approved="yes">
+                <source>Content-Box</source>
+                <target xml:lang="de">Content-Box</target>
+            </trans-unit>
+
+            <!-- properties -->
+            <trans-unit id="properties.contentBoxWidth" xml:space="preserve" approved="yes">
+                <source>Width of the box (in px)</source>
+                <target xml:lang="de">Breite der Box (in px)</target>
+            </trans-unit>
+            <trans-unit id="properties.contentBoxPadding" xml:space="preserve" approved="yes">
+                <source>Inner box padding</source>
+                <target xml:lang="de">Padding der inneren Box</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Translations/en/NodeTypes/Content/Hotspot.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Content/Hotspot.xlf
@@ -5,15 +5,21 @@
             <trans-unit id="ui.label" xml:space="preserve" approved="yes">
                 <source>Hotspot</source>
             </trans-unit>
+
+            <!-- tabs -->
             <trans-unit id="tabs.general" xml:space="preserve" approved="yes">
                 <source>General</source>
             </trans-unit>
+
+            <!-- groups -->
             <trans-unit id="groups.position" xml:space="preserve" approved="yes">
                 <source>Position</source>
             </trans-unit>
             <trans-unit id="groups.icon" xml:space="preserve" approved="yes">
                 <source>Icon</source>
             </trans-unit>
+
+            <!-- properties -->
             <trans-unit id="properties.top" xml:space="preserve" approved="yes">
                 <source>From top</source>
             </trans-unit>

--- a/Resources/Private/Translations/en/NodeTypes/Mixin/HotspotContent.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Mixin/HotspotContent.xlf
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file original="" product-name="Gerdemann.ImageHotspots" source-language="en" datatype="plaintext">
+        <body>
+            <trans-unit id="groups.contentSettings" xml:space="preserve" approved="yes">
+                <source>Content-Box</source>
+            </trans-unit>
+
+            <!-- properties -->
+            <trans-unit id="properties.contentBoxWidth" xml:space="preserve" approved="yes">
+                <source>Width of the box (in px)</source>
+            </trans-unit>
+            <trans-unit id="properties.contentBoxPadding" xml:space="preserve" approved="yes">
+                <source>Inner box padding</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Public/JavaScripts/ImageHotspot.js
+++ b/Resources/Public/JavaScripts/ImageHotspot.js
@@ -1,6 +1,61 @@
+/**
+ * Fix the position of the content boxes if they overlap from the viewport
+ */
+const fixMovingOfHotspotImages = () => {
+    const hotspots = document.querySelectorAll(".imagehotspot-hotspot");
+    hotspots.forEach(hotspot => {
+        /** @type {HTMLElement} */
+        const contentBox = hotspot.querySelector('.imagehotspot-hotspot__content-collapse');
+        if (contentBox) {
+            const bounding = contentBox.getBoundingClientRect();
+            const dataTransformX = parseInt(contentBox.dataset.transformX) || 0;
+
+            // Check if the content-box is out of the viewport on the right side
+            if (bounding.right + (parseInt(contentBox.dataset.transformX) || 0) > (window.innerWidth || document.documentElement.clientWidth)) {
+                const hotspotContainer = contentBox.closest('.imagehotspot-container');
+                const moving = Math.abs(bounding.left + dataTransformX + bounding.width - hotspotContainer.clientWidth) + 15;
+
+                contentBox.style.transform = 'translateX(' + (-moving) + 'px)';
+                contentBox.dataset.transformX = moving;
+            }
+            else {
+                // Reset the transformation if the content can be shown normal
+                if (bounding.right + dataTransformX < (window.innerWidth || document.documentElement.clientWidth)) {
+                    contentBox.style.transform = '';
+                    contentBox.dataset.transformX = '0';
+                }
+            }
+        }
+    });
+}
+
+/**
+ * Trigger an event if the viewport is no longer resized
+ */
+const resizeEndEvent = () => {
+    let resizeId;
+    const resizeEndEvent = new Event('resizeend');
+
+    window.addEventListener('resize', () => {
+        clearTimeout(resizeId);
+        resizeId = setTimeout(doneResizing, 500);
+    }, false);
+
+    const doneResizing = () => {
+        window.dispatchEvent(resizeEndEvent);
+    }
+}
+
+/**
+ * Show the content box of a hotspot and hide all other
+ *
+ * @param e{Event}
+ */
 const selectHotspot = (e) => {
-    const clickedHotspot = e.target.parentElement.parentElement;
-    const container = clickedHotspot.parentElement;
+    /** @type {HTMLElement} **/
+    const clickedHotspot = e.target.closest('.imagehotspot-hotspot');
+    /** @type {HTMLElement} **/
+    const container = clickedHotspot.closest('.imagehotspot-container');
 
     const hotspots = container.querySelectorAll(".imagehotspot-hotspot");
     hotspots.forEach(hotspot => {
@@ -12,9 +67,61 @@ const selectHotspot = (e) => {
     });
 }
 
-(() => {
-    const buttons = document.querySelectorAll(".imagehotspot-hotspot__button img");
-    buttons.forEach(button => {
-        button.addEventListener(('ontouchstart' in window ? 'touchstart' : 'click'), selectHotspot);
+/**
+ * Hide all content boxes if no image hotspot was clicked
+ *
+ * @param e{Event}
+ */
+const closeImageHotspots = (e) => {
+    /** @type {HTMLElement} **/
+    const clickedHotspot = e.target.closest('.imagehotspot-hotspot');
+    /** @type {HTMLElement} **/
+    const container = e.target.closest('.imagehotspot-container');
+
+    if (!clickedHotspot) {
+        const hotspots = container.querySelectorAll(".imagehotspot-hotspot");
+        hotspots.forEach(hotspot => {
+            hotspot.classList.remove('imagehotspot-hotspot--selected');
+        });
+    }
+};
+
+const initImageHotspots = () => {
+    const imageHotspotContainers = document.querySelectorAll('.imagehotspot-container');
+    imageHotspotContainers.forEach((container) => {
+        container.dataset.initialized = '1';
+        container.addEventListener(('ontouchstart' in window ? 'touchstart' : 'click'), closeImageHotspots, false);
     });
+
+    const hotspots = document.querySelectorAll(".imagehotspot-hotspot");
+    hotspots.forEach(hotspot => {
+        const button = hotspot.querySelector('.imagehotspot-hotspot__button');
+        button.addEventListener(('ontouchstart' in window ? 'touchstart' : 'click'), selectHotspot, {passive: true});
+    });
+
+    fixMovingOfHotspotImages();
+    window.addEventListener('resizeend', fixMovingOfHotspotImages, {passive: true});
+};
+
+(() => {
+    resizeEndEvent();
+    initImageHotspots();
+
+    // Fix for the neos-backend if some changes were applied and the hotspots are not reinitialized
+    if (document.querySelector('body.neos-backend')) {
+        document.documentElement.addEventListener('click', (e) => {
+            const imageHotspotContainer = document.querySelector('.imagehotspot-container');
+
+            if (imageHotspotContainer) {
+                if (imageHotspotContainer.dataset.initialized !== '1') {
+                    initImageHotspots();
+
+                    const clickedHotspot = e.target.closest('.imagehotspot-hotspot');
+                    if (clickedHotspot) {
+                        clickedHotspot.classList.add("imagehotspot-hotspot--selected");
+                    }
+                }
+            }
+        }, {passive: true});
+    }
 })();

--- a/Resources/Public/Styles/ImageHotspot.css
+++ b/Resources/Public/Styles/ImageHotspot.css
@@ -18,22 +18,35 @@
 }
 
 .imagehotspot-hotspot--selected {
-    z-index: 99999;
+    z-index: 10;
 }
-.imagehotspot-hotspot--selected .imagehotspot-hotspot__label {
+.imagehotspot-hotspot--selected .imagehotspot-hotspot__content-collapse {
+    visibility: visible;
     opacity: 1;
 }
 
 .imagehotspot-hotspot__button {
+    cursor: pointer;
     height: 20px;
     width: 20px;
     position: relative;
     z-index: 1;
 }
+
+.imagehotspot-hotspot--top-left .imagehotspot-hotspot__content-collapse {
+    top: 24px;
+    left: 24px;
+}
+
 @media (min-width: 768px) {
     .imagehotspot-hotspot__button {
         height: 30px;
         width: 30px;
+    }
+
+    .imagehotspot-hotspot--top-left .imagehotspot-hotspot__content-collapse {
+        top: 35px;
+        left: 35px;
     }
 }
 @media (min-width: 992px) {
@@ -41,27 +54,33 @@
         height: 45px;
         width: 45px;
     }
+
+    .imagehotspot-hotspot--top-left .imagehotspot-hotspot__content-collapse {
+        top: 50px;
+        left: 50px;
+    }
 }
 
-
-.imagehotspot-hotspot__label {
+.imagehotspot-hotspot__content-collapse {
     position: absolute;
     padding: 0 0 1.1em 0;
+    z-index: 2;
+    visibility: collapse;
+    opacity: 0;
+    transition: all 0.3s ease-in-out;
+}
+
+.imagehotspot-hotspot__content {
     width: 16em;
-    max-width: 50vw;
     background-color: white;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
     font-family: "Open Sans", sans-serif;
-    font-size: 14.5px;
+    font-size: 14px;
     line-height: 1.45em;
-    z-index: 2;
-    pointer-events: none;
     border-radius: 2px;
-    user-select: none;
-    opacity: 0;
-    transition: all 0.1s linear;
 }
-.imagehotspot-hotspot__label h4 {
+
+.imagehotspot-hotspot__content h4 {
     margin: 0;
     padding: 0.65em 24px;
     background-color: #555;
@@ -71,13 +90,14 @@
     color: white;
     border-radius: 2px 2px 0 0;
 }
-.imagehotspot-hotspot__label p {
+.imagehotspot-hotspot__content p {
     margin: 0;
     padding: 1.1em 24px 0 24px;
     color: #333;
 }
 
-.imagehotspot-hotspot--top-left .imagehotspot-hotspot__label {
-    top: 24px;
-    left: 24px;
+.imagehotspot-hotspot-headline {
+    min-height: 50px;
+    padding-right: 50px;
+    word-break: break-word;
 }


### PR DESCRIPTION
- Create a default content-collection for the rendering of the
  content-box
  - This makes it easier to make individual customizations as you
    only need to overwrite the Fusion prototype where the content is
    rendered
- Enhance JavaScript so that content is always bundled to the right of the
  screen when it's out of view
- If no hotspot was clicked, all content boxes will be hidden