### PR TITLE
feat!: Add Neos 8, drop Neos 7 support

### DIFF
--- a/Configuration/NodeTypes.Content.Hotspot.yaml
+++ b/Configuration/NodeTypes.Content.Hotspot.yaml
@@ -50,7 +50,7 @@
         reloadIfChanged: true
         inspector:
           group: 'position'
-          editor: 'Shel.Neos.RangeEditor/RangeEditor'
+          editor: 'Neos.Neos/Inspector/Editors/RangeEditor'
           editorOptions:
             min: 0
             max: 100
@@ -64,7 +64,7 @@
         reloadIfChanged: true
         inspector:
           group: 'position'
-          editor: 'Shel.Neos.RangeEditor/RangeEditor'
+          editor: 'Neos.Neos/Inspector/Editors/RangeEditor'
           editorOptions:
             min: 0
             max: 100

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
         "neoscms"
     ],
     "require": {
-        "neos/neos": "^7.0",
-        "shel/neos-rangeeditor": "~1.1.1",
+        "neos/neos": "^8.0",
         "mhsdesign/liveinspectorjsevents": "~2.0.2"
     },
     "autoload": {


### PR DESCRIPTION
Neos 8 has implemented the RangeEditor into the core.

BREAKING CHANGE: Drops Neos 7 support